### PR TITLE
S3 edit applicant save url

### DIFF
--- a/public/js/saveApplicant.js
+++ b/public/js/saveApplicant.js
@@ -213,7 +213,7 @@ let makeApiRequest = async (data, type) => {
             switch (response.status) {
                 case 200:
                     response.json().then(data => {
-                        top.location.href = "https://io-academy.uk/apply/thank-you/";
+                        top.location.href = "../applicants";
                     });
                     break;
                 case 400:


### PR DESCRIPTION
When editing an applicant in the system, the success state of the save button goes to the io live website, it should not. It should go to the table of applicants.