### PR TITLE
Story5 fix applicant modal profile link bug

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -19,7 +19,7 @@ return function (ContainerBuilder $containerBuilder) {
                 'level' => Logger::DEBUG,
             ],
             'db' => [
-                'host' => 'mysql:host=127.0.0.1;',
+                'host' => 'mysql:host=DB;',
                 'dbName' => 'dbname=academyPortal',
                 'userName' => 'root',
                 'password' => 'password'

--- a/public/js/applicantModal.js
+++ b/public/js/applicantModal.js
@@ -67,7 +67,7 @@ export function addEventListenersToDisplayApplicantModal() {
                         response.json().then(function (data) {
 
                             document.querySelectorAll('#applicantModal section.student').forEach(section => {
-                                if (data.isStudentStage === "1") {
+                                if (data.isStudentStage) {
                                     section.classList.remove('hidden')
                                 } else {
                                     section.classList.add('hidden')
@@ -80,7 +80,7 @@ export function addEventListenersToDisplayApplicantModal() {
                             if (data.apprentice === 1) {
                                 document.getElementById('apprentice').innerHTML = 'Apprentice'
                             }
-                            console.log(data);
+
                             displayField(data, 'name')
                             displayField(data, 'email')
                             displayField(data, 'phoneNumber')
@@ -170,7 +170,7 @@ export function addEventListenersToDisplayApplicantModal() {
                             displayField(data, 'additionalNotes', 'No notes')
                             data.chosenCourseDate = prettyDate(data.chosenCourseDate)
                             displayField(data, 'chosenCourseDatePretty', 'Not asked yet')
-                            // displayField(data,'userProfileLink', 'No Link Yet' )
+                            displayField(data,'userProfileLink', 'No Link Yet' )
                         })
                     }
                 )

--- a/public/js/applicantModal.js
+++ b/public/js/applicantModal.js
@@ -170,9 +170,6 @@ export function addEventListenersToDisplayApplicantModal() {
                             displayField(data, 'additionalNotes', 'No notes')
                             data.chosenCourseDate = prettyDate(data.chosenCourseDate)
                             displayField(data, 'chosenCourseDatePretty', 'Not asked yet')
-                            if (!studentUrl) {
-                                displayField(data, 'userProfileLink', 'No Link Yet')
-                            }
                         })
                     }
                 )


### PR DESCRIPTION
Story Requirements:

"the applicant modal is supposed to display a link to the applicants profile page, but it doesnt work. please fix"

From Colin: 
_Bug was fixed by changing the studentUrl variable in applicantModal.js on line 56 to the profile page link
Then in order for it to read the student's id for the proper link, had to concatenate data.id on the end of the link (line 69)
Added an if statement (is not currently necessary) so if there is no link to an applicant's profile it will tell you "No Link Yet"_

Cheers